### PR TITLE
add support for apple m1 chip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.6'
 
 services:
     app:
+        platform:
+            linux/x86_64
         build:
             context: ./
             dockerfile: app/Dockerfile


### PR DESCRIPTION
The current setup in `docker-compose.yml` doesn't allow the environment setup on a mac machine with M1 chip.
This MR will will take care of this problem.