### PR TITLE
Switch to tensorflow base image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,13 +1,7 @@
-FROM ubuntu:bionic-20200219 as base
+FROM tensorflow/tensorflow:1.15.5
 
-RUN apt-get update
-RUN apt-get -y install ssh
-RUN apt-get -y install python3-pip
-RUN apt-get -y install htop
-RUN apt-get -y install libpq-dev
-
-RUN apt-get update 
-RUN apt-get -y install cmake libopenmpi-dev python3-dev zlib1g-dev libgl1-mesa-dev
+RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get -y install cmake libopenmpi-dev python3-dev zlib1g-dev libgl1-mesa-dev ssh python3-pip htop libpq-dev
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --upgrade setuptools


### PR DESCRIPTION
I was getting errors installing tensorflow 1.15 on bionic so I switched the base image to the official tensorflow image at version 1.15.